### PR TITLE
Fixed Discord not recognizing symbols

### DIFF
--- a/switcher.plugin.js
+++ b/switcher.plugin.js
@@ -215,7 +215,7 @@ SwitcherDialog.prototype.createDialog = function(){
 	            </div>\
 	            <div class="markdown-modal-footer">\
 	                <span style="float: right"> \
-		                Use <code>↑↓</code> to move, <code>↩</code> to select \
+		                Use <code>Arrow Keys</code> to move, <code>Enter</code> to select \
 	                </span> \
 	            </div>\
 	        </div>\


### PR DESCRIPTION
Discord would not Recognize the Arrow symbols So i fixed it and just said "Arrow keys" and "Enter"
